### PR TITLE
(fix): export of index.js

### DIFF
--- a/packages/filter-async/package.json
+++ b/packages/filter-async/package.json
@@ -2,7 +2,7 @@
   "name": "filter-async-rxjs-pipe",
   "version": "2.0.1",
   "description": "Some pipeable functions for rxjs 7+ which accept predicate lambdas with async return value (Promise or Observable)",
-  "main": "./dist/src/index.js",
+  "main": "./dist/index.js",
   "files": [
     "dist/**/*", 
     "src/**/*", 


### PR DESCRIPTION
In the current version `2.0.1` I get the following error:

```
TS2307: Cannot find module 'filter-async-rxjs-pipe' or its corresponding type declarations.
8 import { filterByPromise } from 'filter-async-rxjs-pipe';
```